### PR TITLE
Introducing Config Settings

### DIFF
--- a/classes/class.ilObjOpencastEvent.php
+++ b/classes/class.ilObjOpencastEvent.php
@@ -2,6 +2,8 @@
 
 include_once("./Services/Repository/classes/class.ilObjectPlugin.php");
 require_once("./Customizing/global/plugins/Services/Repository/RepositoryObject/OpencastEvent/classes/class.ilObjOpencastEventGUI.php");
+include_once(__DIR__ . "/../src/Config/PluginConfig.php");
+use \elanev\OpencastEvent\Config\PluginConfig as LocalPluginConfig;
 use srag\Plugins\Opencast\Model\Event\EventAPIRepository;
 use srag\Plugins\Opencast\DI\OpencastDIC;
 use srag\Plugins\Opencast\Model\Config\PluginConfig;
@@ -55,15 +57,19 @@ class ilObjOpencastEvent extends ilObjectPlugin
     {
         global $ilDB;
 
+        // Getting new_tab default value from configs.
+        $default_new_tab = (bool) LocalPluginConfig::getConfig(LocalPluginConfig::F_THUMBNAIL_LINK);
+
         $values = [
             $ilDB->quote($this->getId(), "integer"),
             $ilDB->quote(0, "integer"),
             $ilDB->quote($this->getEventId(), "string"),
-            $ilDB->quote(1, "integer"),
+            $ilDB->quote(($default_new_tab ? 1 : 0), "integer"),
             $ilDB->quote(1, "integer"),
         ];
 
-        $insert_sql = "INSERT INTO {$this->table_name} (id, is_online, event_id, new_tab, maximize) VALUES (" . implode(', ', $values) . ")";
+        $insert_sql = "INSERT INTO {$this->table_name} (id, is_online, event_id, new_tab, maximize) VALUES (" .
+            implode(', ', $values) . ")";
 
         $ilDB->manipulate($insert_sql);
     }

--- a/classes/class.ilOpencastEventConfigGUI.php
+++ b/classes/class.ilOpencastEventConfigGUI.php
@@ -1,0 +1,166 @@
+<?php
+include_once("./Services/Form/classes/class.ilPropertyFormGUI.php");
+require_once('./Services/Form/classes/class.ilCheckboxInputGUI.php');
+
+use ilPluginConfigGUI;
+/**
+ * ilOpencastEventConfigGUI
+ *
+ * @author Farbod Zamani Boroujeni <zamani@elan-ev.de>
+ * @extends ilPluginConfigGUI
+ */
+class ilOpencastEventConfigGUI extends ilPluginConfigGUI
+{
+    /**
+     * @var elanev\OpencastEvent\Config\PluginConfig
+     */
+    protected $config_object;
+    /**
+     * @var \ilCtrlInterface
+     */
+    private $ctrl;
+    /**
+     * @var \ilGlobalTemplateInterface
+     */
+    private $main_tpl;
+    /**
+     * @var \ilLanguage
+     */
+    private $language;
+    /**
+     * @var \ilTabsGUI
+     */
+    private $tabs;
+
+    public function __construct()
+    {
+        global $DIC;
+        $this->ctrl = $DIC->ctrl();
+        $this->main_tpl = $DIC->ui()->mainTemplate();
+        $this->language = $DIC->language();
+        $this->tabs = $DIC->tabs();
+
+        include_once(__DIR__ . "/../src/Config/PluginConfig.php");
+        $this->config_object = new \elanev\OpencastEvent\Config\PluginConfig();
+    }
+
+
+    /**
+     * @return array
+     */
+    public function getFields()
+    {
+        return [
+            $this->config_object::F_THUMBNAIL_LINK => [
+                'type' => 'ilCheckboxInputGUI',
+                'hasInfo' => true,
+                'subItems' => [],
+                'value' => (bool) $this->config_object::getConfig($this->config_object::F_THUMBNAIL_LINK) ?? false
+            ]
+        ];
+    }
+
+    public function executeCommand(): void
+    {
+        parent::executeCommand();
+    }
+
+    public function performCommand($cmd): void
+    {
+        switch ($cmd) {
+            case "configure":
+            case "save":
+                $this->$cmd();
+                break;
+        }
+    }
+
+    /**
+     * Configure screen
+     */
+    public function configure(): void
+    {
+        $this->initConfigurationForm();
+        $this->fillForm();
+        $this->main_tpl->setContent($this->form->getHTML());
+    }
+
+    /**
+     * Set form item values
+     */
+    private function fillForm(): void
+    {
+        $values = [];
+        foreach ($this->getFields() as $key => $item) {
+            if (isset($item['value'])) {
+                $values[$key] = $item['value'];
+            }
+        }
+        $this->form->setValuesByArray($values);
+    }
+
+
+    /**
+     * @return ilPropertyFormGUI
+     */
+    public function initConfigurationForm(): \ilPropertyFormGUI
+    {
+        $this->form = new ilPropertyFormGUI();
+
+        foreach ($this->getFields() as $key => $item) {
+            $field = new $item['type']($this->txt($key), $key);
+            if (!empty($item['hasInfo'])) {
+                $field->setInfo($this->txt($key . '_info'));
+            }
+            $this->form->addItem($field);
+        }
+
+        $this->form->addCommandButton("save", $this->language->txt("save"));
+
+        $this->form->setTitle($this->txt("header"));
+        $this->form->setFormAction($this->ctrl->getFormAction($this));
+
+        return $this->form;
+    }
+
+    /**
+     * Saves the config.
+     */
+    public function save(): void
+    {
+        $this->initConfigurationForm();
+        if ($this->form->checkInput()) {
+            foreach ($this->getFields() as $key => $item) {
+                $form_value = $this->form->getInput($key) ?? null;
+                if (!is_null($form_value)) {
+                    $this->config_object::setConfig($key, $form_value);
+                }
+                if (isset($item['subItems']) && !empty($item['subItems'])) {
+                    foreach ($item['subItems'] as $subkey => $subitem) {
+                        $subitem_form_value = $this->form->getInput($key . "_" . $subkey) ?? null;
+                        if (!is_null($subitem_form_value)) {
+                            $this->config_object::setConfig($key . "_" . $subkey, $subitem_form_value);
+                        }
+                    }
+                }
+            }
+            ilUtil::sendSuccess(
+                $this->txt("saved"),
+                true
+            );
+            $this->ctrl->redirect($this, "configure");
+        } else {
+            $this->form->setValuesByPost();
+            $this->main_tpl->setContent($this->form->getHtml());
+        }
+    }
+
+    /**
+     * @param string $key the key lang string
+     * @return string
+     */
+    public function txt($key): string
+    {
+        return $this->plugin_object->txt('config_' . $key);
+    }
+}

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -51,3 +51,7 @@ table_row_tooltip_txt#:#Klicken Sie auf diese Zeile, um dieses Video auszuwähle
 table_row_tooltip_txt_not_selectable#:#Dieses Video kann aufgrund eines ungeeigneten Verarbeitungsstatus nicht ausgewählt werden
 oc_video_section#:#Opencast Video
 settings_section#:#Einstellungen
+config_header#:#Konfigurationen
+config_saved#:#Die Einstellungen wurden erfolgreich gespeichert.
+config_thumbnail_link#:#Standardwert für "Vorschaubild als Link"
+config_thumbnail_link_info#:#Der Standardwert für die Einstellungsoption "Vorschaubild als Link zum Video". Administratoren können den Standardwert für diese Einstellungsoption festlegen, der den Benutzern beim Erstellen eines Opencast-Ereignisobjekts angezeigt wird.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -51,3 +51,7 @@ table_row_tooltip_txt#:#Click on this row to select this video
 table_row_tooltip_txt_not_selectable#:#This video cannot be selected because of ineligible processing state
 oc_video_section#:#Opencast Video
 settings_section#:#Settings
+config_header#:#Configurations
+config_saved#:#Settings have been successfully saved.
+config_thumbnail_link#:#"Thumbnail as a link" default value
+config_thumbnail_link_info#:#The default value for the "Thumbnail as a link to the video" setting option. Admins are able to set the default value for this setting option that is displayed to the users upon creating an Opencast Event object.

--- a/plugin.php
+++ b/plugin.php
@@ -1,6 +1,6 @@
 <?php
 $id = "xoce";
-$version = "1.0.0";
+$version = "1.1.0";
 $ilias_min_version = "6.0";
 $ilias_max_version = "7.999";
 $responsible = "ELAN e.V.";

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -43,3 +43,23 @@ if (!$ilDB->tableExists("rep_robj_xoce_data")) {
     $ilDB->addPrimaryKey("rep_robj_xoce_data", array("id"));
 }
 ?>
+<#2>
+<?php
+// introducing configuration table.
+if (!$ilDB->tableExists("rep_robj_xoce_config")) {
+    $fields = array(
+        'name' => array(
+            'type' => 'text',
+            'length' => 250,
+            'notnull' => true
+        ),
+        'value' => array(
+            'type' => 'text',
+            'length' => 4000,
+            'notnull' => false
+        )
+    );
+    $ilDB->createTable("rep_robj_xoce_config", $fields);
+    $ilDB->addPrimaryKey("rep_robj_xoce_config", array("name"));
+}
+?>

--- a/src/Config/PluginConfig.php
+++ b/src/Config/PluginConfig.php
@@ -1,0 +1,122 @@
+<?php
+namespace elanev\OpencastEvent\Config;
+
+use ActiveRecord;
+
+class PluginConfig extends ActiveRecord
+{
+    public const TABLE_NAME = 'rep_robj_xoce_config';
+    public const F_THUMBNAIL_LINK = 'thumbnail_link';
+
+    /**
+     * @var array
+     */
+    protected static $cached_config = [];
+
+    /**
+     * @return string
+     */
+    public static function returnDbTableName()
+    {
+        return self::TABLE_NAME;
+    }
+
+    /**
+     * @return string
+     */
+    public function getConnectorContainerName()
+    {
+        return self::TABLE_NAME;
+    }
+
+    /**
+     * @var string
+     * @db_has_field        true
+     * @db_is_unique        true
+     * @db_is_primary       true
+     * @db_is_notnull       true
+     * @db_fieldtype        text
+     * @db_length           250
+     */
+    protected $name;
+
+    /**
+     * @var string
+     * @db_has_field        true
+     * @db_fieldtype        text
+     * @db_length           4000
+     */
+    protected $value;
+
+    /**
+     * @param string $name
+     */
+    public function setName($name): void
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $value
+     */
+    public function setValue($value): void
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    /**
+     * @param $name
+     * @return mixed
+     */
+    public static function getConfig($name)
+    {
+        if (!isset(self::$cached_config[$name])) {
+            if (self::where(['name' => $name])->hasSets()) {
+                $obj = new self($name);
+                try {
+                    self::$cached_config[$name] = json_decode($obj->getValue());
+                } catch (\Exception $e) {
+                    return null;
+                }
+            } else {
+                return null;
+            }
+        }
+
+        return self::$cached_config[$name];
+    }
+
+    /**
+     * @param $name
+     * @param $value
+     */
+    public static function setConfig($name, $value): void
+    {
+        if (self::where(['name' => $name])->hasSets()) {
+            $obj = new self($name);
+            $obj->setValue(json_encode($value));
+            $obj->update();
+        } else {
+            $obj = new self;
+            $obj->setName($name);
+            $obj->setValue(json_encode($value));
+            $obj->create();
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes #8,

### Description
please refer to related issue #8 

### How it works
- with this PR `PlugingConfig` class is implemented that works similar to Opencast Series Object, without considering the default values on the first install!
- The new Thumbnail as link default value is added to the settings, by which admins are able to define the default value for that settings that user will see when creating/editing the `OpencastEvent` object in a course!


### Important to know
- This PR is on top of PR #6, because it has some critical fixes that made the plugin functional. Therefore, any changes to parent PR will be applied here as well.

- This PR increases the plugin to `1.1.0`, due to a new db update No. 2

This PR is included into #12 