### PR TITLE
[FIX] Declare $form property in ilOpencastEventConfigGUI #22

### DIFF
--- a/classes/class.ilOpencastEventConfigGUI.php
+++ b/classes/class.ilOpencastEventConfigGUI.php
@@ -32,6 +32,10 @@ class ilOpencastEventConfigGUI extends ilPluginConfigGUI
      * @var \ilTabsGUI
      */
     protected ilTabsGUI $tabs;
+    /**
+     * @var \ilPropertyFormGUI
+     */
+    protected ilPropertyFormGUI $form;
 
     public function __construct()
     {


### PR DESCRIPTION
Fixes #22.

Opening **Plugin Administration → Configure** raised:

> Creation of dynamic property `ilOpencastEventConfigGUI::$form` is deprecated (E_DEPRECATED, PHP 8.2/8.3)

`$this->form` was assigned in `initConfigurationForm()` without a class property declaration. This declares it explicitly (`protected ilPropertyFormGUI $form;`).