### PR TITLE
[REFACTOR] Modernise plugin for ILIAS 10

### DIFF
--- a/classes/Listing/OpencastEventListing.php
+++ b/classes/Listing/OpencastEventListing.php
@@ -191,19 +191,32 @@ class OpencastEventListing
      */
     protected function getListingSortValue(): string
     {
-        if (
-            $this->dic->http()->wrapper()->query()->has(self::F_SORT_QUERY_PARAM) &&
-            $this->dic->http()->wrapper()->query()->retrieve(
-                self::F_SORT_QUERY_PARAM,
-                $this->dic->refinery()->kindlyTo()->string()
-            )
-        ) {
-            return $this->dic->http()->wrapper()->query()->retrieve(
-                self::F_SORT_QUERY_PARAM,
-                $this->dic->refinery()->kindlyTo()->string()
-            );
+        return $this->retrieveQueryParam(
+            self::F_SORT_QUERY_PARAM,
+            $this->dic->refinery()->kindlyTo()->string(),
+            self::F_SORT_START_DESC
+        );
+    }
+
+    /**
+     * Retrieve and transform a query parameter, falling back to a default
+     * when the parameter is absent or its transformed value is empty.
+     *
+     * @param string $key Query parameter name.
+     * @param \ILIAS\Refinery\Transformation $transformation Transformation to apply.
+     * @param mixed $default Default returned when the parameter is missing/empty.
+     * @return mixed Transformed value or default.
+     */
+    private function retrieveQueryParam(
+        string $key,
+        \ILIAS\Refinery\Transformation $transformation,
+        mixed $default
+    ): mixed {
+        $query = $this->dic->http()->wrapper()->query();
+        if (!$query->has($key)) {
+            return $default;
         }
-        return self::F_SORT_START_DESC;
+        return $query->retrieve($key, $transformation) ?: $default;
     }
 
     /**
@@ -232,14 +245,11 @@ class OpencastEventListing
      */
     protected function getCurrentPage(): int
     {
-        $current_page = 0;
-        if ($this->dic->http()->wrapper()->query()->has(self::F_PAGINATION_QUERY_PARAM)) {
-            $current_page = $this->dic->http()->wrapper()->query()->retrieve(
-                self::F_PAGINATION_QUERY_PARAM,
-                $this->dic->refinery()->kindlyTo()->int()
-            );
-        }
-        return (int) $current_page;
+        return (int) $this->retrieveQueryParam(
+            self::F_PAGINATION_QUERY_PARAM,
+            $this->dic->refinery()->kindlyTo()->int(),
+            0
+        );
     }
     /**
      * Calculate the API page offset for event fetch requests.

--- a/classes/Listing/OpencastEventListing.php
+++ b/classes/Listing/OpencastEventListing.php
@@ -104,6 +104,37 @@ class OpencastEventListing
     }
 
     /**
+     * Create an ilTemplate from the plugin's default template directory.
+     *
+     * @param string $file Template file name.
+     * @param bool $remove_unknown_variables Strip unresolved template variables.
+     */
+    private function template(string $file, bool $remove_unknown_variables = true): ilTemplate
+    {
+        return new ilTemplate(
+            $this->plugin->getDirectory() . '/templates/default/' . $file,
+            true,
+            $remove_unknown_variables
+        );
+    }
+
+    /**
+     * Set the given variables on a template block and parse it.
+     *
+     * @param ilTemplate $tpl Target template.
+     * @param string $block Block name to fill.
+     * @param array<string, string> $variables Variable name => value pairs.
+     */
+    private function fillBlock(ilTemplate $tpl, string $block, array $variables): void
+    {
+        $tpl->setCurrentBlock($block);
+        foreach ($variables as $name => $value) {
+            $tpl->setVariable($name, $value);
+        }
+        $tpl->parseCurrentBlock();
+    }
+
+    /**
      * Build and return the standard UI filter component for event listing.
      *
      * Includes fields for text search, series selection, and start date range.
@@ -303,44 +334,20 @@ class OpencastEventListing
             }
 
             // Preparing the ID property with extra spans to be used by js functions.
-            $span_id_tpl = new ilTemplate(
-                $this->plugin->getDirectory() . '/templates/default/tpl.OpencastEventListPropSpanId.html',
-                true,
-                true
-            );
-            $span_id_tpl->setCurrentBlock('id');
-            $span_id_tpl->setVariable('ID', $event->getIdentifier());
-            $span_id_tpl->parseCurrentBlock();
-
-            $span_id_tpl->setCurrentBlock('title');
-            $span_id_tpl->setVariable('TITLE', $event->getTitle());
-            $span_id_tpl->parseCurrentBlock();
-
-            $span_id_tpl->setCurrentBlock('desc');
-            $span_id_tpl->setVariable('DESC', $event->getDescription());
-            $span_id_tpl->parseCurrentBlock();
+            $span_id_tpl = $this->template('tpl.OpencastEventListPropSpanId.html');
+            $this->fillBlock($span_id_tpl, 'id', ['ID' => $event->getIdentifier()]);
+            $this->fillBlock($span_id_tpl, 'title', ['TITLE' => $event->getTitle()]);
+            $this->fillBlock($span_id_tpl, 'desc', ['DESC' => $event->getDescription()]);
 
             // Preparing the Status property with extra spans to be used by js functions.
             $selectable = $event->getProcessingState() == Event::STATE_SUCCEEDED;
-            $span_status_tpl = new ilTemplate(
-                $this->plugin->getDirectory() . '/templates/default/tpl.OpencastEventListPropSpanStatus.html',
-                true,
-                true
-            );
-            $span_status_tpl->setCurrentBlock('selectable');
-            $span_status_tpl->setVariable('SELECTABLE', $selectable ? 'true' : 'false');
-            $span_status_tpl->parseCurrentBlock();
-
-            $span_status_tpl->setCurrentBlock('text');
             $item_status_txt = $selectable ?
                 $this->plugin->txt('list_item_status_txt') :
                 $this->plugin->txt('list_item_status_txt_not_selectable');
-            $span_status_tpl->setVariable('TEXT', $item_status_txt);
-            $span_status_tpl->parseCurrentBlock();
-
-            $span_status_tpl->setCurrentBlock('selected');
-            $span_status_tpl->setVariable('SELECTED', $this->plugin->txt('list_item_status_selected_txt'));
-            $span_status_tpl->parseCurrentBlock();
+            $span_status_tpl = $this->template('tpl.OpencastEventListPropSpanStatus.html');
+            $this->fillBlock($span_status_tpl, 'selectable', ['SELECTABLE' => $selectable ? 'true' : 'false']);
+            $this->fillBlock($span_status_tpl, 'text', ['TEXT' => $item_status_txt]);
+            $this->fillBlock($span_status_tpl, 'selected', ['SELECTED' => $this->plugin->txt('list_item_status_selected_txt')]);
 
             /** @disregard P1013 The method "withLeadImage" exists but intelephense cannot find it! */
             $items[] = $item->withProperties([
@@ -440,23 +447,11 @@ class OpencastEventListing
      */
     protected function renderListingAfterForm(string $listing_html, string $filter_html): string
     {
-        $edit_event_form_tpl = new ilTemplate(
-            $this->plugin->getDirectory() . '/templates/default/tpl.OpencastEventEdit.html',
-            true,
-            true
-        );
+        $edit_event_form_tpl = $this->template('tpl.OpencastEventEdit.html');
 
-        $edit_event_form_tpl->setCurrentBlock('form');
-        $edit_event_form_tpl->setVariable('FORM', $this->form->getHTML());
-        $edit_event_form_tpl->parseCurrentBlock();
-
-        $edit_event_form_tpl->setCurrentBlock('filter');
-        $edit_event_form_tpl->setVariable('FILTER', $filter_html);
-        $edit_event_form_tpl->parseCurrentBlock();
-
-        $edit_event_form_tpl->setCurrentBlock('listing');
-        $edit_event_form_tpl->setVariable('LISTING', $listing_html);
-        $edit_event_form_tpl->parseCurrentBlock();
+        $this->fillBlock($edit_event_form_tpl, 'form', ['FORM' => $this->form->getHTML()]);
+        $this->fillBlock($edit_event_form_tpl, 'filter', ['FILTER' => $filter_html]);
+        $this->fillBlock($edit_event_form_tpl, 'listing', ['LISTING' => $listing_html]);
 
         return $edit_event_form_tpl->get();
     }
@@ -473,27 +468,13 @@ class OpencastEventListing
      */
     protected function renderListingWithingForm(string $listing_html, string $filter_html): string
     {
-        $new_event_form_tpl = new ilTemplate(
-            $this->plugin->getDirectory() . '/templates/default/tpl.OpencastEventCreate.html',
-            true,
-            true
-        );
+        $new_event_form_tpl = $this->template('tpl.OpencastEventCreate.html');
 
-        $new_event_form_tpl->setCurrentBlock('filter');
-        $new_event_form_tpl->setVariable('FILTER', $filter_html);
-        $new_event_form_tpl->parseCurrentBlock();
+        $this->fillBlock($new_event_form_tpl, 'filter', ['FILTER' => $filter_html]);
 
         $new_event_form_tpl->setCurrentBlock('form');
-        $footer_replace_tpl = new ilTemplate(
-            $this->plugin->getDirectory() . '/templates/default/tpl.OpencastEventFooterReplace.html',
-            true,
-            false
-        );
-        $event_listing_replace_tpl = new ilTemplate(
-            $this->plugin->getDirectory() . '/templates/default/tpl.OpencastEventFormEventListingReplace.html',
-            true,
-            true
-        );
+        $footer_replace_tpl = $this->template('tpl.OpencastEventFooterReplace.html', false);
+        $event_listing_replace_tpl = $this->template('tpl.OpencastEventFormEventListingReplace.html');
 
         $event_listing_replace_tpl->setVariable('LISTING', $listing_html);
         $event_listing_replace_tpl->setVariable('FOOTER', $footer_replace_tpl->get());

--- a/classes/Listing/OpencastEventListing.php
+++ b/classes/Listing/OpencastEventListing.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace elanev\OpencastEvent\Listing;
 
 use ilOpencastEventPlugin;
-use ilOpenCastPlugin;
 use ilTemplate;
 use ILIAS\UI\Factory;
 use ILIAS\UI\Renderer;
@@ -77,38 +76,21 @@ class OpencastEventListing
     /** @var int the default constant for API limit of events */
     public const F_PAGINATION_API_LIMIT = 1000;
 
-    /**
-     * @var \ILIAS\DI\Container
-     */
     protected \ILIAS\DI\Container $dic;
-    /**
-     * @var Factory
-     */
     private Factory $ui_factory;
-    /**
-     * @var Renderer
-     */
     private Renderer $renderer;
-    /**
-     * @var ilOpencastEventPlugin
-     */
     protected ilOpencastEventPlugin $plugin;
-    /**
-     * @var ilOpenCastPlugin
-     */
-    private ilOpenCastPlugin $opencast_plugin;
 
     /** @var string the filter id */
     public string $filter_id;
 
-    /** @var Translator */
     private Translator $opencast_translator;
 
 
     function __construct(
         protected \ilObjOpencastEventGUI $gui,
         protected ilPropertyFormGUI $form,
-        private int $ref_id = 0,
+        int $ref_id = 0,
         private bool $is_new = true
     ) {
         global $DIC;
@@ -117,7 +99,6 @@ class OpencastEventListing
         $this->renderer = $DIC->ui()->renderer();
         $this->plugin = $this->gui->getPlugin();
         $opencast_dic = Init::init();
-        $this->opencast_plugin = $opencast_dic[ilOpenCastPlugin::class];
         $this->opencast_translator = $opencast_dic->translator();
         $this->filter_id = $this->gui::class . '_filter_' . $ref_id;
     }
@@ -127,8 +108,6 @@ class OpencastEventListing
      *
      * Includes fields for text search, series selection, and start date range.
      * The filter is bound to the current listing action link.
-     *
-     * @return \ILIAS\UI\Component\Input\Container\Filter\Standard
      */
     protected function getListingFilter(): StandardFilter
     {
@@ -147,7 +126,7 @@ class OpencastEventListing
 
         $action = $this->getActionLink('filter');
 
-        $filter = $this->dic->uiService()->filter()->standard(
+        return $this->dic->uiService()->filter()->standard(
             $this->filter_id,
             $action,
             $filter_inputs,
@@ -155,14 +134,11 @@ class OpencastEventListing
             true,
             true
         );
-
-        return $filter;
     }
 
     /**
      * Extract selected filter values from a standard filter component.
      *
-     * @param \ILIAS\UI\Component\Input\Container\Filter\Standard $filter
      * @return array|null Filter values as associative array or null when no data.
      */
     protected function getListingFilterData(StandardFilter $filter): ?array
@@ -173,7 +149,6 @@ class OpencastEventListing
     /**
      * Render the filter component into HTML.
      *
-     * @param \ILIAS\UI\Component\Input\Container\Filter\Standard $filter
      * @return string HTML output for the filter bar.
      */
     protected function renderListingFilters(StandardFilter $filter): string
@@ -189,12 +164,10 @@ class OpencastEventListing
      * - title asc/desc
      * - series asc/desc
      * - location asc/desc
-     *
-     * @return \ILIAS\UI\Component\ViewControl\Sortation
      */
     protected function getListingSort(): \ILIAS\UI\Component\ViewControl\Sortation
     {
-        $sortation = $this->ui_factory->viewControl()->sortation(
+        return $this->ui_factory->viewControl()->sortation(
             [
                 self::F_SORT_START_ASC      => $this->plugin->txt(self::F_SORT_START_ASC),
                 self::F_SORT_START_DESC     => $this->plugin->txt(self::F_SORT_START_DESC),
@@ -207,8 +180,6 @@ class OpencastEventListing
             ],
             $this->getListingSortValue()
         )->withTargetURL($this->getActionLink('sortation'), self::F_SORT_QUERY_PARAM);
-
-        return $sortation;
     }
 
     /**
@@ -220,7 +191,6 @@ class OpencastEventListing
      */
     protected function getListingSortValue(): string
     {
-        $selected = self::F_SORT_START_DESC;
         if (
             $this->dic->http()->wrapper()->query()->has(self::F_SORT_QUERY_PARAM) &&
             $this->dic->http()->wrapper()->query()->retrieve(
@@ -228,23 +198,22 @@ class OpencastEventListing
                 $this->dic->refinery()->kindlyTo()->string()
             )
         ) {
-            $selected = $this->dic->http()->wrapper()->query()->retrieve(
+            return $this->dic->http()->wrapper()->query()->retrieve(
                 self::F_SORT_QUERY_PARAM,
                 $this->dic->refinery()->kindlyTo()->string()
             );
         }
-        return $selected;
+        return self::F_SORT_START_DESC;
     }
 
     /**
      * Create pagination controls for event listing.
      *
      * @param int $total Total number of items (for pagination calculation).
-     * @return \ILIAS\UI\Component\ViewControl\Pagination
      */
     protected function getListingPagination(int $total): \ILIAS\UI\Component\ViewControl\Pagination
     {
-        $pagination = $this->ui_factory->viewControl()->pagination()
+        return $this->ui_factory->viewControl()->pagination()
             ->withTargetURL(
                 $this->getActionLink('pagination'), self::F_PAGINATION_QUERY_PARAM
             )
@@ -252,7 +221,6 @@ class OpencastEventListing
             ->withPageSize(self::F_PAGINATION_PER_PAGE)
             ->withMaxPaginationButtons(2)
             ->withCurrentPage($this->getCurrentPage());
-        return $pagination;
     }
 
     /**
@@ -284,8 +252,7 @@ class OpencastEventListing
     protected function getApiOffset(): int
     {
         $global_offset = $this->getCurrentPage() * self::F_PAGINATION_PER_PAGE;
-        $api_page = intdiv($global_offset, self::F_PAGINATION_API_LIMIT);
-        return $api_page;
+        return intdiv($global_offset, self::F_PAGINATION_API_LIMIT);
     }
 
     /**

--- a/classes/class.ilObjOpencastEvent.php
+++ b/classes/class.ilObjOpencastEvent.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use \elanev\OpencastEvent\Config\PluginConfig as LocalPluginConfig;
 use srag\Plugins\Opencast\Model\Event\EventAPIRepository;
 use srag\Plugins\Opencast\Container\Init;
-use srag\Plugins\Opencast\Model\Config\PluginConfig;
 
 /**
  * Class ilObjOpencastEventAccess
@@ -14,9 +13,8 @@ use srag\Plugins\Opencast\Model\Config\PluginConfig;
  */
 class ilObjOpencastEvent extends ilObjectPlugin
 {
-    protected $table_name;
+    protected string $table_name = ilOpencastEventPlugin::TABLE_NAME;
 
-    /** @var EventAPIRepository*/
     private EventAPIRepository $event_repository;
 
     private bool $online = false;
@@ -30,11 +28,9 @@ class ilObjOpencastEvent extends ilObjectPlugin
      * Constructor
      *
      * @access        public
-     * @param int $a_ref_id
      */
     public function __construct(int $a_ref_id = 0)
     {
-        $this->table_name = ilOpencastEventPlugin::TABLE_NAME;
         $opencast_dic = Init::init();
         $this->event_repository = $opencast_dic[EventAPIRepository::class];
 
@@ -100,10 +96,10 @@ class ilObjOpencastEvent extends ilObjectPlugin
             $latest_title = $event->getTitle();
             $latest_description = $event->getDescription();
             if ($event) {
-                if ($latest_title != $this->getTitle()) {
+                if ($latest_title !== $this->getTitle()) {
                     $this->setTitle($latest_title);
                 }
-                if ($latest_description != $this->getDescription()) {
+                if ($latest_description !== $this->getDescription()) {
                     $this->setDescription($latest_description);
                 }
             }
@@ -176,7 +172,7 @@ class ilObjOpencastEvent extends ilObjectPlugin
      */
     public function isOnline(): bool
     {
-        return $this->online ? true : false;
+        return $this->online;
     }
 
     /**
@@ -206,7 +202,7 @@ class ilObjOpencastEvent extends ilObjectPlugin
      */
     public function setWidth(int $a_val): void
     {
-        $this->width = $a_val ? intval($a_val) : null;
+        $this->width = $a_val !== 0 ? intval($a_val) : null;
     }
 
     /**
@@ -216,7 +212,7 @@ class ilObjOpencastEvent extends ilObjectPlugin
      */
     public function getWidth(): int
     {
-        return !empty($this->width) ? $this->width : 0;
+        return empty($this->width) ? 0 : $this->width;
     }
 
     /**
@@ -226,7 +222,7 @@ class ilObjOpencastEvent extends ilObjectPlugin
      */
     public function setHeight(int $a_val): void
     {
-        $this->height = $a_val ? intval($a_val) : null;
+        $this->height = $a_val !== 0 ? intval($a_val) : null;
     }
 
     /**
@@ -236,7 +232,7 @@ class ilObjOpencastEvent extends ilObjectPlugin
      */
     public function getHeight(): int
     {
-        return !empty($this->height) ? $this->height : 0;
+        return empty($this->height) ? 0 : $this->height;
     }
 
     /**
@@ -256,7 +252,7 @@ class ilObjOpencastEvent extends ilObjectPlugin
      */
     public function getNewTab(): bool
     {
-        return $this->new_tab ? true : false;
+        return $this->new_tab;
     }
 
     /**
@@ -276,6 +272,6 @@ class ilObjOpencastEvent extends ilObjectPlugin
      */
     public function getMaximize(): bool
     {
-        return $this->maximize ? true : false;
+        return $this->maximize;
     }
 }

--- a/classes/class.ilObjOpencastEvent.php
+++ b/classes/class.ilObjOpencastEvent.php
@@ -50,23 +50,16 @@ class ilObjOpencastEvent extends ilObjectPlugin
      */
     public function doCreate(bool $clone_mode = false): void
     {
-        global $ilDB;
-
         // Getting new_tab default value from configs.
         $default_new_tab = (bool) LocalPluginConfig::getConfig(LocalPluginConfig::F_THUMBNAIL_LINK);
 
-        $values = [
-            $ilDB->quote($this->getId(), "integer"),
-            $ilDB->quote(0, "integer"),
-            $ilDB->quote($this->getEventId(), "string"),
-            $ilDB->quote(($default_new_tab ? 1 : 0), "integer"),
-            $ilDB->quote(1, "integer"),
-        ];
-
-        $insert_sql = "INSERT INTO {$this->table_name} (id, is_online, event_id, new_tab, maximize) VALUES (" .
-            implode(', ', $values) . ")";
-
-        $ilDB->manipulate($insert_sql);
+        $this->db->insert($this->table_name, [
+            'id' => ['integer', $this->getId()],
+            'is_online' => ['integer', 0],
+            'event_id' => ['text', $this->getEventId()],
+            'new_tab' => ['integer', $default_new_tab ? 1 : 0],
+            'maximize' => ['integer', 1],
+        ]);
     }
 
     /**
@@ -74,18 +67,17 @@ class ilObjOpencastEvent extends ilObjectPlugin
      */
     public function doRead(): void
     {
-        global $ilDB;
+        $set = $this->db->queryF(
+            'SELECT * FROM ' . $this->table_name . ' WHERE id = %s',
+            ['integer'],
+            [$this->getId()]
+        );
 
-        $object_id = $ilDB->quote($this->getId(), "integer");
-        $select_sql = "SELECT * FROM {$this->table_name} WHERE id = $object_id";
-
-        $set = $ilDB->query($select_sql);
-
-        while ($rec = $ilDB->fetchAssoc($set)) {
+        while ($rec = $this->db->fetchAssoc($set)) {
             $this->setOnline(!empty($rec["is_online"]));
             $this->setEventId($rec["event_id"]);
-            $this->setWidth($rec["width"] ? intval($rec["width"]) : 0);
-            $this->setHeight($rec["height"] ? intval($rec["height"]) : 0);
+            $this->setWidth((int) $rec["width"]);
+            $this->setHeight((int) $rec["height"]);
             $this->setNewTab(!empty($rec["new_tab"]));
             $this->setMaximize(!empty($rec["maximize"]));
         }
@@ -112,20 +104,16 @@ class ilObjOpencastEvent extends ilObjectPlugin
      */
     public function doUpdate(): void
     {
-        global $ilDB;
-
-        $values = [
-            'is_online = ' . $ilDB->quote($this->isOnline(), "integer"),
-            'event_id = ' . $ilDB->quote($this->getEventId(), "string"),
-            'new_tab = ' . $ilDB->quote($this->getNewTab(), "integer"),
-            'width = ' . $ilDB->quote($this->getWidth(), "integer"),
-            'height = ' . $ilDB->quote($this->getHeight(), "integer"),
-            'maximize = ' . $ilDB->quote($this->getMaximize(), "integer"),
-        ];
-        $object_id = $ilDB->quote($this->getId(), "integer");
-
-        $update_sql = "UPDATE {$this->table_name} SET " . implode(', ', $values) . " WHERE id = $object_id";
-        $ilDB->manipulate($up = $update_sql);
+        $this->db->update($this->table_name, [
+            'is_online' => ['integer', (int) $this->isOnline()],
+            'event_id' => ['text', $this->getEventId()],
+            'new_tab' => ['integer', (int) $this->getNewTab()],
+            'width' => ['integer', $this->getWidth()],
+            'height' => ['integer', $this->getHeight()],
+            'maximize' => ['integer', (int) $this->getMaximize()],
+        ], [
+            'id' => ['integer', $this->getId()],
+        ]);
     }
 
     /**
@@ -133,12 +121,11 @@ class ilObjOpencastEvent extends ilObjectPlugin
      */
     public function doDelete(): void
     {
-        global $ilDB;
-
-        $object_id = $ilDB->quote($this->getId(), "integer");
-
-        $delete_sql = "DELETE FROM {$this->table_name} WHERE id = $object_id";
-        $ilDB->manipulate($delete_sql);
+        $this->db->manipulateF(
+            'DELETE FROM ' . $this->table_name . ' WHERE id = %s',
+            ['integer'],
+            [$this->getId()]
+        );
     }
 
     /**

--- a/classes/class.ilObjOpencastEventAccess.php
+++ b/classes/class.ilObjOpencastEventAccess.php
@@ -10,6 +10,17 @@ declare(strict_types=1);
 class ilObjOpencastEventAccess extends ilObjectPluginAccess
 {
     /**
+     * Default RBAC permissions granted per parent-course role on creation.
+     *
+     * @var array<string, list<string>>
+     */
+    private const DEFAULT_PERMISSIONS = [
+        'member' => ['visible', 'read'],
+        'tutor' => ['visible', 'read', 'copy'],
+        'admin' => ['visible', 'read', 'copy', 'write', 'delete'],
+    ];
+
+    /**
      * Checks whether a user may invoke a command or not
      * (this method is called by ilAccessHandler::checkAccess)
      *
@@ -25,21 +36,23 @@ class ilObjOpencastEventAccess extends ilObjectPluginAccess
      */
     public function _checkAccess(string $a_cmd, string $a_permission, int $a_ref_id, int $a_obj_id, ?int $a_user_id = null): bool
     {
-        global $ilUser, $ilAccess;
+        global $DIC;
 
-        if ($a_user_id == 0) {
-            $a_user_id = $ilUser->getId();
+        if (!$a_user_id) {
+            $a_user_id = $DIC->user()->getId();
         }
+
+        $access = $DIC->access();
 
         switch ($a_permission) {
             case "read":
-                if (!ilObjOpencastEventAccess::checkOnline($a_obj_id) &&
-                    !$ilAccess->checkAccessOfUser($a_user_id, "write", "", $a_ref_id)) {
+                if (!self::checkOnline($a_obj_id) &&
+                    !$access->checkAccessOfUser($a_user_id, "write", "", $a_ref_id)) {
                     return false;
                 }
                 break;
             case "write":
-                return $ilAccess->checkAccessOfUser($a_user_id, "write", "", $a_ref_id);
+                return $access->checkAccessOfUser($a_user_id, "write", "", $a_ref_id);
         }
 
         return true;
@@ -50,15 +63,17 @@ class ilObjOpencastEventAccess extends ilObjectPluginAccess
      */
     public static function checkOnline(int $a_id): bool
     {
-        global $ilDB;
+        global $DIC;
 
-        $object_id = $ilDB->quote($a_id, "integer");
-        $select_sql = "SELECT is_online FROM " . ilOpencastEventPlugin::TABLE_NAME . " WHERE id = $object_id";
+        $db = $DIC->database();
+        $set = $db->queryF(
+            'SELECT is_online FROM ' . ilOpencastEventPlugin::TABLE_NAME . ' WHERE id = %s',
+            ['integer'],
+            [$a_id]
+        );
 
-        $set = $ilDB->query($select_sql);
-
-        $rec = $ilDB->fetchAssoc($set);
-        return (bool) $rec["is_online"];
+        $rec = $db->fetchAssoc($set);
+        return (bool) ($rec["is_online"] ?? false);
     }
 
     /**
@@ -71,66 +86,31 @@ class ilObjOpencastEventAccess extends ilObjectPluginAccess
         global $DIC;
         $parent_id = $DIC->repositoryTree()->getParentId($ref_id);
         $parent_obj = ilObjectFactory::getInstanceByRefId($parent_id);
-        if (!$parent_obj instanceof \ilObject) {
+        if (!$parent_obj instanceof ilObjCourse) {
             return;
         }
-        self::setDefaultMemberPerms($ref_id, $parent_obj);
-        self::setDefaultTutorPerms($ref_id, $parent_obj);
-        self::setDefaultAdminPerms($ref_id, $parent_obj);
+
+        self::grantPermissions($ref_id, $parent_obj->getDefaultMemberRole(), self::DEFAULT_PERMISSIONS['member']);
+        self::grantPermissions($ref_id, $parent_obj->getDefaultTutorRole(), self::DEFAULT_PERMISSIONS['tutor']);
+        self::grantPermissions($ref_id, $parent_obj->getDefaultAdminRole(), self::DEFAULT_PERMISSIONS['admin']);
     }
 
     /**
-     * Sets default RBAC permissions for members
+     * Grants the given named permissions to a role on a reference.
      *
      * @param int $ref_id ref id
-     * @param ilObjCourse $parent_obj the parent object
+     * @param int $role_id role to grant the permissions to
+     * @param list<string> $permissions permission operation names
      */
-    private static function setDefaultMemberPerms(int $ref_id, ilObjCourse $parent_obj): void
+    private static function grantPermissions(int $ref_id, int $role_id, array $permissions): void
     {
         global $DIC;
-        $member_role_id = $parent_obj->getDefaultMemberRole();
-        $member_roles = ['visible', 'read'];
-        $ops_ids = [];
-        foreach ($member_roles as $role_name) {
-            $ops_ids[] = $DIC->rbac()->review()->_getOperationIdByName($role_name);
-        }
-        $DIC->rbac()->admin()->grantPermission($member_role_id, $ops_ids, $ref_id);
-    }
-
-    /**
-     * Sets default RBAC permissions for tutors
-     *
-     * @param int $ref_id ref id
-     * @param ilObjCourse $parent_obj the parent object
-     */
-    private static function setDefaultTutorPerms(int $ref_id, ilObjCourse $parent_obj): void
-    {
-        global $DIC;
-        $tutor_role_id = $parent_obj->getDefaultTutorRole();
-        $tutor_roles = ['visible', 'read', 'copy'];
-        $ops_ids = [];
-        foreach ($tutor_roles as $role_name) {
-            $ops_ids[] = $DIC->rbac()->review()->_getOperationIdByName($role_name);
-        }
-        $DIC->rbac()->admin()->grantPermission($tutor_role_id, $ops_ids, $ref_id);
-    }
-
-    /**
-     * Sets default RBAC permissions for admins
-     *
-     * @param int $ref_id ref id
-     * @param ilObjCourse $parent_obj the parent object
-     */
-    private static function setDefaultAdminPerms(int $ref_id, ilObjCourse $parent_obj): void
-    {
-        global $DIC;
-        $admin_role_id = $parent_obj->getDefaultAdminRole();
-        $admin_roles = ['visible', 'read', 'copy', 'write', 'delete'];
-        $ops_ids = [];
-        foreach ($admin_roles as $role_name) {
-            $ops_ids[] = $DIC->rbac()->review()->_getOperationIdByName($role_name);
-        }
-        $DIC->rbac()->admin()->grantPermission($admin_role_id, $ops_ids, $ref_id);
+        $review = $DIC->rbac()->review();
+        $ops_ids = array_map(
+            static fn(string $name): int => $review->_getOperationIdByName($name),
+            $permissions
+        );
+        $DIC->rbac()->admin()->grantPermission($role_id, $ops_ids, $ref_id);
     }
 
     /**
@@ -138,7 +118,7 @@ class ilObjOpencastEventAccess extends ilObjectPluginAccess
      */
     public static function isAnonymousUser(): bool
     {
-        global $ilUser;
-        return $ilUser->getId() === ANONYMOUS_USER_ID;
+        global $DIC;
+        return $DIC->user()->getId() === ANONYMOUS_USER_ID;
     }
 }

--- a/classes/class.ilObjOpencastEventAccess.php
+++ b/classes/class.ilObjOpencastEventAccess.php
@@ -40,7 +40,6 @@ class ilObjOpencastEventAccess extends ilObjectPluginAccess
                 break;
             case "write":
                 return $ilAccess->checkAccessOfUser($a_user_id, "write", "", $a_ref_id);
-                break;
         }
 
         return true;
@@ -48,8 +47,6 @@ class ilObjOpencastEventAccess extends ilObjectPluginAccess
 
     /**
      * Checks whether the Object is online
-     * @param int $a_id
-     * @return bool
      */
     public static function checkOnline(int $a_id): bool
     {
@@ -74,7 +71,7 @@ class ilObjOpencastEventAccess extends ilObjectPluginAccess
         global $DIC;
         $parent_id = $DIC->repositoryTree()->getParentId($ref_id);
         $parent_obj = ilObjectFactory::getInstanceByRefId($parent_id);
-        if (!$parent_obj) {
+        if (!$parent_obj instanceof \ilObject) {
             return;
         }
         self::setDefaultMemberPerms($ref_id, $parent_obj);
@@ -138,7 +135,6 @@ class ilObjOpencastEventAccess extends ilObjectPluginAccess
 
     /**
      * Checks if the user is anonymous.
-     * @return bool
      */
     public static function isAnonymousUser(): bool
     {

--- a/classes/class.ilObjOpencastEventGUI.php
+++ b/classes/class.ilObjOpencastEventGUI.php
@@ -107,6 +107,17 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
     }
 
     /**
+     * Typed accessor for the current object, so plugin-specific methods are
+     * resolvable without per-call type hints.
+     */
+    private function getEventObject(): ilObjOpencastEvent
+    {
+        /** @var ilObjOpencastEvent $object */
+        $object = $this->object;
+        return $object;
+    }
+
+    /**
      * Handles all commmands of this class, centralizes permission checks
      *
      * @param string $cmd Command
@@ -318,8 +329,8 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
     {
         $this->tabs->activateTab('content');
         $content_html = '';
-        /** @disregard P1013 The method "getEventId" exists in ilObjOpencastEvent::getEventId */
-        $event_id = $this->object->getEventId();
+        $event_obj = $this->getEventObject();
+        $event_id = $event_obj->getEventId();
         $event = $this->getEvent($event_id);
         if (!empty($event)) {
             $this->main_tpl->addCss($this->getPlugin()->getResourcesPath() . '/templates/css/player.min.css');
@@ -327,11 +338,9 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
                 json_encode($this->getPlayerJSConfig()) .
             ');');
             $stream_url = $this->ctrl->getLinkTarget($this, 'streamVideo');
-            /** @disregard P1013 The method "getNewTab" exists in ilObjOpencastEvent::getNewTab */
-            $tpl_name = $this->object->getNewTab() ? 'tpl.OpencastEventPlayer.html' : 'tpl.OpencastEventPlayerEmbed.html';
+            $tpl_name = $event_obj->getNewTab() ? 'tpl.OpencastEventPlayer.html' : 'tpl.OpencastEventPlayerEmbed.html';
             $tpl = new ilTemplate($this->getPlugin()->getDirectory() . '/templates/default/' . $tpl_name, true, true);
-            /** @disregard P1013 The method "getNewTab" exists in ilObjOpencastEvent::getNewTab */
-            if ($this->object->getNewTab()) {
+            if ($event_obj->getNewTab()) {
                 $tpl->setVariable('VIDEO_LINK', $stream_url);
                 $tpl->setVariable('THUMBNAIL_URL', $event->publications()->getThumbnailUrl());
                 $tpl->setVariable('OVERLAY_ICON_URL', $this->getPlugin()->getResourcesPath() . '/templates/images/play.svg');
@@ -349,8 +358,7 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
      */
     public function streamVideo(): void
     {
-        /** @disregard P1013 The method "getEventId" exists in ilObjOpencastEvent::getEventId */
-        $event_id = $this->object->getEventId();
+        $event_id = $this->getEventObject()->getEventId();
         $event = $this->getEvent($event_id);
         if (empty($event)) {
             echo "Error: Event not found";
@@ -466,13 +474,11 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
      */
     protected function getPlayerJSConfig(): stdClass
     {
+        $event_obj = $this->getEventObject();
         $js_config = new stdClass();
-        /** @disregard P1013 The method "getMaximize" exists in ilObjOpencastEvent::getMaximize */
-        $js_config->maximize = $this->object->getMaximize();
-        /** @disregard P1013 The method "getWidth" exists in ilObjOpencastEvent::getWidth */
-        $js_config->width = $this->object->getWidth() ?: self::DEFAULT_WIDTH;
-        /** @disregard P1013 The method "getHeight" exists in ilObjOpencastEvent::getHeight */
-        $js_config->height = $this->object->getHeight() ?: self::DEFAULT_HEIGHT;
+        $js_config->maximize = $event_obj->getMaximize();
+        $js_config->width = $event_obj->getWidth() ?: self::DEFAULT_WIDTH;
+        $js_config->height = $event_obj->getHeight() ?: self::DEFAULT_HEIGHT;
         return $js_config;
     }
 
@@ -521,24 +527,19 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
         if (empty($event)) {
             return;
         }
-        $this->object->setTitle($event->getTitle());
-        $this->object->setDescription($event->getDescription());
-        /** @disregard P1013 The method "setOnline" exists in ilObjOpencastEvent::setOnline */
-        $this->object->setOnline((bool) $form->getInput('online'));
-        /** @disregard P1013 The method "setEventId" exists in ilObjOpencastEvent::setEventId */
-        $this->object->setEventId($form->getInput('event_id'));
-        /** @disregard P1013 The method "setNewTab" exists in ilObjOpencastEvent::setNewTab */
-        $this->object->setNewTab((bool) $form->getInput('new_tab'));
-        /** @disregard P1013 The method "setMaximize" exists in ilObjOpencastEvent::setMaximize */
-        $this->object->setMaximize($form->getInput('size_type') == 'maximize');
+        $event_obj = $this->getEventObject();
+        $event_obj->setTitle($event->getTitle());
+        $event_obj->setDescription($event->getDescription());
+        $event_obj->setOnline((bool) $form->getInput('online'));
+        $event_obj->setEventId($form->getInput('event_id'));
+        $event_obj->setNewTab((bool) $form->getInput('new_tab'));
+        $event_obj->setMaximize($form->getInput('size_type') == 'maximize');
         if ($form->getInput('size_type') == 'custom') {
             $embed_size = $form->getInput('embed_size');
-            /** @disregard P1013 The method "setWidth" exists in ilObjOpencastEvent::setWidth */
-            $this->object->setWidth(intval($embed_size['width'], 10));
-            /** @disregard P1013 The method "setHeight" exists in ilObjOpencastEvent::setHeight */
-            $this->object->setHeight(intval($embed_size['height'], 10));
+            $event_obj->setWidth((int) $embed_size['width']);
+            $event_obj->setHeight((int) $embed_size['height']);
         }
-        $this->object->update();
+        $event_obj->update();
     }
 
     /**
@@ -608,16 +609,14 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
             $size_type->addOption($size_type_custom);
 
             // preview image
+            $event_obj = $this->getEventObject();
             $preview_image = new ilNonEditableValueGUI($this->opencast_translator->translate('event_preview'), '', true);
-            /** @disregard P1013 The method "setWidth" exists in ilObjOpencastEvent::setWidth */
-            $preview_image_width = $this->object->getWidth() ?: self::DEFAULT_WIDTH;
-            /** @disregard P1013 The method "getHeight" exists in ilObjOpencastEvent::getHeight */
-            $preview_image_height = $this->object->getHeight() ?: self::DEFAULT_HEIGHT;
+            $preview_image_width = $event_obj->getWidth() ?: self::DEFAULT_WIDTH;
+            $preview_image_height = $event_obj->getHeight() ?: self::DEFAULT_HEIGHT;
             $preview_image_tpl = new ilTemplate($this->getPlugin()->getDirectory() . '/templates/default/tpl.OpencastEventPreviewImage.html', false, false);
             $preview_image_tpl->setVariable('DYNAMIC_WIDTH', $preview_image_width);
             $preview_image_tpl->setVariable('DYNAMIC_HEIGHT', $preview_image_height);
-            /** @disregard P1013 The method "getEventId" exists in ilObjOpencastEvent::getEventId */
-            $event_id = $this->object->getEventId();
+            $event_id = $event_obj->getEventId();
             $event = $this->getEvent($event_id);
             if (!empty($event)) {
                 $preview_image_tpl->setVariable('SRC', $event->publications()->getThumbnailUrl());
@@ -697,24 +696,23 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
      */
     protected function addValuesToForm(ilPropertyFormGUI &$form): void
     {
-        /** @disregard P1013 The methods exist in ilObjOpencastEvent class */
+        $event_obj = $this->getEventObject();
         $values_array = [
-            'title' => $this->object->getTitle(),
-            'description' => $this->object->getDescription(),
-            'online' => $this->object->isOnline(),
-            'event_id' => $this->object->getEventId(),
-            'event_id_display' => $this->object->getEventId(),
-            'current_title' => $this->object->getTitle(),
-            'current_event_id' => $this->object->getEventId(),
+            'title' => $event_obj->getTitle(),
+            'description' => $event_obj->getDescription(),
+            'online' => $event_obj->isOnline(),
+            'event_id' => $event_obj->getEventId(),
+            'event_id_display' => $event_obj->getEventId(),
+            'current_title' => $event_obj->getTitle(),
+            'current_event_id' => $event_obj->getEventId(),
             'embed_size' => [
-                'width' => $this->object->getWidth() ?: self::DEFAULT_WIDTH,
-                'height' => $this->object->getHeight() ?: self::DEFAULT_HEIGHT,
+                'width' => $event_obj->getWidth() ?: self::DEFAULT_WIDTH,
+                'height' => $event_obj->getHeight() ?: self::DEFAULT_HEIGHT,
                 'constr_prop' => true
             ],
-            'new_tab' => $this->object->getNewtab()
+            'new_tab' => $event_obj->getNewtab()
         ];
-        /** @disregard P1013 The method "getMaximize" exists in ilObjOpencastEvent::getMaximize */
-        $size_type = $this->object->getMaximize() ? 'maximize' : 'custom';
+        $size_type = $event_obj->getMaximize() ? 'maximize' : 'custom';
         $values_array['size_type'] = $size_type;
         if (isset($this->change_event) && $this->change_event) {
             $values_array['change_event'] = true;

--- a/classes/class.ilObjOpencastEventGUI.php
+++ b/classes/class.ilObjOpencastEventGUI.php
@@ -31,42 +31,28 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
     public const DEFAULT_HEIGHT = 540;
     public const DEFAULT_LIMIT = 10;
 
-    /** @var \ILIAS\DI\Container */
     protected \ILIAS\DI\Container $dic;
 
-    /** @var  ilCtrl */
     protected ilCtrl $ctrl;
 
-    /** @var  ilTabsGUI */
     protected ilTabsGUI $tabs;
 
-    /** @var  ilGlobalTemplateInterface */
     public ilGlobalTemplateInterface $main_tpl;
 
-    /** @var ilTree */
     public ilTree $tree;
 
-    /** @var EventAPIRepository*/
     public EventAPIRepository $event_repository;
 
-    /** @var SeriesRepository */
     public SeriesRepository $series_repository;
 
-    /** @var ilOpenCastPlugin */
     private ilOpenCastPlugin $opencast_plugin;
 
-    /** @var PaellaConfigServiceFactory */
     private PaellaConfigServiceFactory $paellaConfigServiceFactory;
 
-    /** @var PaellaConfigService */
     private PaellaConfigService $paellaConfigService;
 
-    /** @var Translator */
     private Translator $opencast_translator;
 
-    /**
-     * @var \ILIAS\HTTP\Services
-     */
     private \ILIAS\HTTP\Services $http;
 
     /**
@@ -98,8 +84,7 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
 
         $this->ref_id = $this->retrieveQueryParam(
             'ref_id',
-            $this->dic->refinery()->kindlyTo()->int(),
-            null
+            $this->dic->refinery()->kindlyTo()->int()
         );
 
         $this->change_event = $this->retrieveQueryParam(
@@ -203,11 +188,9 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
             $this->ctrl->redirectByClass('ilDashboardGUI', '');
         }
 
-        $forms = [
+        return [
             self::CFORM_NEW => $this->initCreateForm($a_new_type),
         ];
-
-        return $forms;
     }
 
     ///////////////////
@@ -264,15 +247,10 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
                 $this->main_tpl->setOnScreenMessage('success', $this->txt("create_successful"), true);
 
                 $args = func_get_args();
-                if ($args) {
-                    $this->afterSave($newEventObj, $args);
-                } else {
-                    $this->afterSave($newEventObj);
-                }
+                $this->afterSave($newEventObj);
                 return;
-            } else {
-                $this->main_tpl->setOnScreenMessage('failure', $this->txt("msg_creation_failed"));
             }
+            $this->main_tpl->setOnScreenMessage('failure', $this->txt("msg_creation_failed"));
         }
 
         $this->ctrl->redirect($this, 'create');
@@ -346,7 +324,7 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
         if (!empty($event)) {
             $this->main_tpl->addCss($this->getPlugin()->getResourcesPath() . '/templates/css/player.min.css');
             $this->main_tpl->addOnLoadCode('il.OpencastEvent.player.init(' .
-                json_encode($this->getPlayerJSConfig($event)) .
+                json_encode($this->getPlayerJSConfig()) .
             ');');
             $stream_url = $this->ctrl->getLinkTarget($this, 'streamVideo');
             /** @disregard P1013 The method "getNewTab" exists in ilObjOpencastEvent::getNewTab */
@@ -414,12 +392,10 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
 
         if ($event->isLiveEvent()) {
             $paella_player_tpl->setVariable('LIVE_WAITING_TEXT', $this->opencast_translator->translate(
-                'live_waiting_text',
-                'event',
-                [date('H:i', $event->getScheduling()->getStart()->getTimestamp())]
+                'live_waiting_text'
             ));
-            $paella_player_tpl->setVariable('LIVE_INTERRUPTED_TEXT', $this->opencast_translator->translate('live_interrupted_text', 'event'));
-            $paella_player_tpl->setVariable('LIVE_OVER_TEXT', $this->opencast_translator->translate('live_over_text', 'event'));
+            $paella_player_tpl->setVariable('LIVE_INTERRUPTED_TEXT', $this->opencast_translator->translate('live_interrupted_text'));
+            $paella_player_tpl->setVariable('LIVE_OVER_TEXT', $this->opencast_translator->translate('live_over_text'));
         }
 
         $paella_player_tpl->setVariable(
@@ -427,7 +403,7 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
             ILIAS_HTTP_PATH . '/' .
                 strstr($this->opencast_plugin->getDirectory(), 'Customizing/') . '/templates/default/player.css'
         );
-        setcookie('lastProfile', "", -1);
+        setcookie('lastProfile', "", ['expires' => -1]);
         echo $paella_player_tpl->get();
         exit();
     }
@@ -465,7 +441,7 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
 
             $js_config->paella_preview_fallback = $this->paellaConfigService->getPaellaPlayerPreviewFallback();
         } else {
-            $paella_config = $this->paellaConfigService->getEffectivePaellaPlayerUrl($event->isLiveEvent());
+            $paella_config = $this->paellaConfigService->getEffectivePaellaPlayerUrl();
             $js_config->paella_player_folder = $this->opencast_plugin->getDirectory() . '/node_modules/paellaplayer/build/player';
         }
 
@@ -494,16 +470,15 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
         /** @disregard P1013 The method "getMaximize" exists in ilObjOpencastEvent::getMaximize */
         $js_config->maximize = $this->object->getMaximize();
         /** @disregard P1013 The method "getWidth" exists in ilObjOpencastEvent::getWidth */
-        $js_config->width = $this->object->getWidth() ? $this->object->getWidth() : self::DEFAULT_WIDTH;
+        $js_config->width = $this->object->getWidth() ?: self::DEFAULT_WIDTH;
         /** @disregard P1013 The method "getHeight" exists in ilObjOpencastEvent::getHeight */
-        $js_config->height = $this->object->getHeight() ? $this->object->getHeight() : self::DEFAULT_HEIGHT;
+        $js_config->height = $this->object->getHeight() ?: self::DEFAULT_HEIGHT;
         return $js_config;
     }
 
     /**
      * Helper function to create the Opencast Event Object
      *
-     * @param ilPropertyFormGUI $form
      *
      * @return ilObjOpencastEvent $newObj or null if event object cannot be found from xoct
      */
@@ -539,8 +514,6 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
 
     /**
      * Helper function to update the Opencast Event Object
-     *
-     * @param ilPropertyFormGUI $form
      */
     private function updateOpencastEventObject(ilPropertyFormGUI $form): void
     {
@@ -551,13 +524,13 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
         $this->object->setTitle($event->getTitle());
         $this->object->setDescription($event->getDescription());
         /** @disregard P1013 The method "setOnline" exists in ilObjOpencastEvent::setOnline */
-        $this->object->setOnline($form->getInput('online') ? true : false);
+        $this->object->setOnline((bool) $form->getInput('online'));
         /** @disregard P1013 The method "setEventId" exists in ilObjOpencastEvent::setEventId */
         $this->object->setEventId($form->getInput('event_id'));
         /** @disregard P1013 The method "setNewTab" exists in ilObjOpencastEvent::setNewTab */
-        $this->object->setNewTab($form->getInput('new_tab') ? true : false);
+        $this->object->setNewTab((bool) $form->getInput('new_tab'));
         /** @disregard P1013 The method "setMaximize" exists in ilObjOpencastEvent::setMaximize */
-        $this->object->setMaximize($form->getInput('size_type') == 'maximize' ? true : false);
+        $this->object->setMaximize($form->getInput('size_type') == 'maximize');
         if ($form->getInput('size_type') == 'custom') {
             $embed_size = $form->getInput('embed_size');
             /** @disregard P1013 The method "setWidth" exists in ilObjOpencastEvent::setWidth */
@@ -571,7 +544,6 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
     /**
      * Helper function to custom checks the form input.
      *
-     * @param ilPropertyFormGUI $form
      *
      * @return bool based on the checkers defined, returns true of false.
      */
@@ -638,9 +610,9 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
             // preview image
             $preview_image = new ilNonEditableValueGUI($this->opencast_translator->translate('event_preview'), '', true);
             /** @disregard P1013 The method "setWidth" exists in ilObjOpencastEvent::setWidth */
-            $preview_image_width = $this->object->getWidth() ? $this->object->getWidth() : self::DEFAULT_WIDTH;
+            $preview_image_width = $this->object->getWidth() ?: self::DEFAULT_WIDTH;
             /** @disregard P1013 The method "getHeight" exists in ilObjOpencastEvent::getHeight */
-            $preview_image_height = $this->object->getHeight() ? $this->object->getHeight() : self::DEFAULT_HEIGHT;
+            $preview_image_height = $this->object->getHeight() ?: self::DEFAULT_HEIGHT;
             $preview_image_tpl = new ilTemplate($this->getPlugin()->getDirectory() . '/templates/default/tpl.OpencastEventPreviewImage.html', false, false);
             $preview_image_tpl->setVariable('DYNAMIC_WIDTH', $preview_image_width);
             $preview_image_tpl->setVariable('DYNAMIC_HEIGHT', $preview_image_height);
@@ -703,7 +675,6 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
 
     /**
      * Gets the config for range slider
-     * @return array
      */
     private function getRangeSliderConfig(): array
     {
@@ -736,8 +707,8 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
             'current_title' => $this->object->getTitle(),
             'current_event_id' => $this->object->getEventId(),
             'embed_size' => [
-                'width' => $this->object->getWidth() ? $this->object->getWidth() : self::DEFAULT_WIDTH,
-                'height' => $this->object->getHeight() ? $this->object->getHeight() : self::DEFAULT_HEIGHT,
+                'width' => $this->object->getWidth() ?: self::DEFAULT_WIDTH,
+                'height' => $this->object->getHeight() ?: self::DEFAULT_HEIGHT,
                 'constr_prop' => true
             ],
             'new_tab' => $this->object->getNewtab()
@@ -753,7 +724,6 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
 
     /**
      * Gets the opencast event plugin
-     * @return ilOpencastEventPlugin
      */
     public function getPlugin(): ilOpencastEventPlugin
     {
@@ -762,17 +732,13 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
 
     /**
      * Checks if the parent object is course or group, to prevent access otherwise!
-     *
-     * @return bool
      */
     private function checkParentGroupCourse(): bool
     {
-        $is_checked = false;
-        if (isset($this->ref_id) && $this->tree->checkForParentType($this->ref_id, 'grp') > 0 ||
-            $this->tree->checkForParentType($this->ref_id, 'crs') > 0) {
-            $is_checked = true;
+        if (isset($this->ref_id) && $this->tree->checkForParentType($this->ref_id, 'grp') > 0) {
+            return true;
         }
-        return $is_checked;
+        return $this->tree->checkForParentType($this->ref_id, 'crs') > 0;
     }
 
     /**

--- a/classes/class.ilObjOpencastEventGUI.php
+++ b/classes/class.ilObjOpencastEventGUI.php
@@ -118,6 +118,14 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
     }
 
     /**
+     * Return the stored dimension or the given default when none is set.
+     */
+    private function effectiveDimension(int $value, int $default): int
+    {
+        return $value ?: $default;
+    }
+
+    /**
      * Handles all commmands of this class, centralizes permission checks
      *
      * @param string $cmd Command
@@ -477,8 +485,8 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
         $event_obj = $this->getEventObject();
         $js_config = new stdClass();
         $js_config->maximize = $event_obj->getMaximize();
-        $js_config->width = $event_obj->getWidth() ?: self::DEFAULT_WIDTH;
-        $js_config->height = $event_obj->getHeight() ?: self::DEFAULT_HEIGHT;
+        $js_config->width = $this->effectiveDimension($event_obj->getWidth(), self::DEFAULT_WIDTH);
+        $js_config->height = $this->effectiveDimension($event_obj->getHeight(), self::DEFAULT_HEIGHT);
         return $js_config;
     }
 
@@ -611,8 +619,8 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
             // preview image
             $event_obj = $this->getEventObject();
             $preview_image = new ilNonEditableValueGUI($this->opencast_translator->translate('event_preview'), '', true);
-            $preview_image_width = $event_obj->getWidth() ?: self::DEFAULT_WIDTH;
-            $preview_image_height = $event_obj->getHeight() ?: self::DEFAULT_HEIGHT;
+            $preview_image_width = $this->effectiveDimension($event_obj->getWidth(), self::DEFAULT_WIDTH);
+            $preview_image_height = $this->effectiveDimension($event_obj->getHeight(), self::DEFAULT_HEIGHT);
             $preview_image_tpl = new ilTemplate($this->getPlugin()->getDirectory() . '/templates/default/tpl.OpencastEventPreviewImage.html', false, false);
             $preview_image_tpl->setVariable('DYNAMIC_WIDTH', $preview_image_width);
             $preview_image_tpl->setVariable('DYNAMIC_HEIGHT', $preview_image_height);
@@ -706,8 +714,8 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
             'current_title' => $event_obj->getTitle(),
             'current_event_id' => $event_obj->getEventId(),
             'embed_size' => [
-                'width' => $event_obj->getWidth() ?: self::DEFAULT_WIDTH,
-                'height' => $event_obj->getHeight() ?: self::DEFAULT_HEIGHT,
+                'width' => $this->effectiveDimension($event_obj->getWidth(), self::DEFAULT_WIDTH),
+                'height' => $this->effectiveDimension($event_obj->getHeight(), self::DEFAULT_HEIGHT),
                 'constr_prop' => true
             ],
             'new_tab' => $event_obj->getNewtab()

--- a/classes/class.ilObjOpencastEventGUI.php
+++ b/classes/class.ilObjOpencastEventGUI.php
@@ -842,18 +842,10 @@ class ilObjOpencastEventGUI extends ilObjectPluginGUI
         \ILIAS\Refinery\Transformation $transformation,
         mixed $default = null
     ): mixed {
-        if (
-            $this->http->wrapper()->query()->has($key) &&
-            $this->http->wrapper()->query()->retrieve(
-                $key,
-                $transformation
-            )
-        ) {
-            return $this->http->wrapper()->query()->retrieve(
-                $key,
-                $transformation
-            );
+        $query = $this->http->wrapper()->query();
+        if (!$query->has($key)) {
+            return $default;
         }
-        return $default;
+        return $query->retrieve($key, $transformation) ?: $default;
     }
 }

--- a/classes/class.ilObjOpencastEventListGUI.php
+++ b/classes/class.ilObjOpencastEventListGUI.php
@@ -10,10 +10,6 @@ declare(strict_types=1);
 class ilObjOpencastEventListGUI extends ilObjectPluginListGUI
 {
     /**
-     * @var bool
-     */
-    public $payment_enabled;
-    /**
      * Init type
      */
     public function initType(): void
@@ -37,7 +33,6 @@ class ilObjOpencastEventListGUI extends ilObjectPluginListGUI
         // Always set
         $this->timings_enabled = true;
         $this->subscribe_enabled = true;
-        $this->payment_enabled = false;
         $this->link_enabled = true;
         $this->info_screen_enabled = true;
         $this->delete_enabled = true;

--- a/classes/class.ilObjOpencastEventListGUI.php
+++ b/classes/class.ilObjOpencastEventListGUI.php
@@ -10,6 +10,10 @@ declare(strict_types=1);
 class ilObjOpencastEventListGUI extends ilObjectPluginListGUI
 {
     /**
+     * @var bool
+     */
+    public $payment_enabled;
+    /**
      * Init type
      */
     public function initType(): void
@@ -44,7 +48,7 @@ class ilObjOpencastEventListGUI extends ilObjectPluginListGUI
         $this->cut_enabled = true;
         $this->copy_enabled = true;
 
-        $commands = [
+        return [
             [
                 'permission' => 'read',
                 'cmd' => 'showContent',
@@ -56,8 +60,6 @@ class ilObjOpencastEventListGUI extends ilObjectPluginListGUI
                 "txt" => $this->txt('event_settings')
             ],
         ];
-
-        return $commands;
     }
 
     /**
@@ -84,19 +86,16 @@ class ilObjOpencastEventListGUI extends ilObjectPluginListGUI
     }
 
     /**
-    * Get all item information (title, commands, description) in HTML
-    *
-    * @access	public
-    * @param	int			$a_ref_id		item reference id
-    * @param	int			$a_obj_id		item object id
-    * @param	string		$a_title		item title
-    * @param	string		$a_description	item description
-    * @param	bool		$a_use_asynch
-    * @param	bool		$a_get_asynch_commands
-    * @param	string		$a_asynch_url
-    * @param	int		    $a_context	    workspace/tree context
-    * @return	string		html code
-    */
+     * Get all item information (title, commands, description) in HTML
+     *
+     * @access	public
+     * @param	int			$a_ref_id		item reference id
+     * @param	int			$a_obj_id		item object id
+     * @param	string		$a_title		item title
+     * @param	string		$a_description	item description
+     * @param	int		    $a_context	    workspace/tree context
+     * @return	string		html code
+     */
     public function getListItemHTML(
         int $a_ref_id,
         int $a_obj_id,

--- a/classes/class.ilOpencastEventConfigGUI.php
+++ b/classes/class.ilOpencastEventConfigGUI.php
@@ -12,7 +12,7 @@ use elanev\OpencastEvent\Config\PluginConfig as LocalPluginConfig;
  */
 class ilOpencastEventConfigGUI extends ilPluginConfigGUI
 {
-    public $form;
+    protected ilPropertyFormGUI $form;
     protected LocalPluginConfig $config_object;
     protected ilCtrlInterface $ctrl;
     protected ilGlobalTemplateInterface $main_tpl;

--- a/classes/class.ilOpencastEventConfigGUI.php
+++ b/classes/class.ilOpencastEventConfigGUI.php
@@ -12,25 +12,11 @@ use elanev\OpencastEvent\Config\PluginConfig as LocalPluginConfig;
  */
 class ilOpencastEventConfigGUI extends ilPluginConfigGUI
 {
-    /**
-     * @var elanev\OpencastEvent\Config\PluginConfig
-     */
+    public $form;
     protected LocalPluginConfig $config_object;
-    /**
-     * @var \ilCtrlInterface
-     */
     protected ilCtrlInterface $ctrl;
-    /**
-     * @var \ilGlobalTemplateInterface
-     */
     protected ilGlobalTemplateInterface $main_tpl;
-    /**
-     * @var \ilLanguage
-     */
     protected ilLanguage $language;
-    /**
-     * @var \ilTabsGUI
-     */
     protected ilTabsGUI $tabs;
 
     public function __construct()
@@ -44,9 +30,6 @@ class ilOpencastEventConfigGUI extends ilPluginConfigGUI
     }
 
 
-    /**
-     * @return array
-     */
     public function getFields(): array
     {
         return [
@@ -99,9 +82,6 @@ class ilOpencastEventConfigGUI extends ilPluginConfigGUI
     }
 
 
-    /**
-     * @return ilPropertyFormGUI
-     */
     public function initConfigurationForm(): \ilPropertyFormGUI
     {
         $this->form = new \ilPropertyFormGUI();
@@ -153,7 +133,6 @@ class ilOpencastEventConfigGUI extends ilPluginConfigGUI
 
     /**
      * @param string $key the key lang string
-     * @return string
      */
     public function txt(string $key): string
     {

--- a/classes/class.ilOpencastEventPlugin.php
+++ b/classes/class.ilOpencastEventPlugin.php
@@ -51,7 +51,6 @@ class ilOpencastEventPlugin extends ilRepositoryObjectPlugin
 
     /**
      * Provide a readable path for loading the resources like js and css files by ILIAS.
-     * @return string
      */
     public function getResourcesPath(): string
     {

--- a/src/Config/PluginConfig.php
+++ b/src/Config/PluginConfig.php
@@ -15,17 +15,11 @@ class PluginConfig extends ActiveRecord
      */
     protected static $cached_config = [];
 
-    /**
-     * @return string
-     */
     public static function returnDbTableName(): string
     {
         return self::TABLE_NAME;
     }
 
-    /**
-     * @return string
-     */
     public function getConnectorContainerName(): string
     {
         return self::TABLE_NAME;
@@ -50,42 +44,26 @@ class PluginConfig extends ActiveRecord
      */
     protected $value;
 
-    /**
-     * @param string $name
-     */
     public function setName(string $name): void
     {
         $this->name = $name;
     }
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $value
-     */
     public function setValue(string $value): void
     {
         $this->value = $value;
     }
 
-    /**
-     * @return string
-     */
     public function getValue(): string
     {
         return $this->value;
     }
 
-    /**
-     * @param string $name
-     * @return mixed
-     */
     public static function getConfig(string $name): mixed
     {
         if (!isset(self::$cached_config[$name])) {
@@ -106,7 +84,6 @@ class PluginConfig extends ActiveRecord
 
     /**
      * @param string $name
-     * @param mixed $value
      */
     public static function setConfig(?string $name, mixed $value): void
     {


### PR DESCRIPTION
Modernises the plugin for ILIAS 10 in small, reviewable steps (release_10 only). No behaviour change intended; the plugin still installs, activates and updates cleanly via the setup CLI.

**Commits**
1. `sr rector:plugin` pass (typed properties, dropped redundant docblocks, early returns, strict comparisons, removal of dead arguments to single-parameter API calls).
2. Tighten `$form` to `protected ilPropertyFormGUI`; drop the dead `payment_enabled` flag (no longer exists in `ilObjectListGUI`, unused in core).
3. Collapse the three near-identical `setDefault{Member,Tutor,Admin}Perms` into one `grantPermissions()` helper driven by a permission map; replace `global $ilDB/$ilUser/$ilAccess` with `$DIC` services; parameterise `checkOnline` via `queryF`.
4. Use the inherited `ilObject::$db` abstraction (`insert/update/queryF/manipulateF`) in `ilObjOpencastEvent` instead of hand-built SQL strings and `global $ilDB`; drop the stray `$up =` assignment.
5. Retrieve each query parameter only once (was fetched twice — to test then to return); share one `retrieveQueryParam()` helper for sort and pagination in the listing.
6. Add a typed `getEventObject()` accessor and route plugin-specific getters/setters through it, removing the 18 per-call `@disregard P1013` annotations.

License headers were left untouched (`sr rector:plugin --no-license`).